### PR TITLE
fix: typos in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `yggdrasil-worker-package-manager` is a simple package manager yggd worker. It
 knows how to install and remove packages, add, remove, enable and disable
-repositories, and does rudamentary detection of the host its running on to guess
+repositories, and does rudimentary detection of the host it is running on to guess
 the package manager to use. It only installs packages that match one of the
 provided `allow-pattern` regular expressions.
 

--- a/main.go
+++ b/main.go
@@ -34,7 +34,9 @@ func main() {
 	fs.Var(&allowPatterns, "allow-pattern", "regular expression pattern to allow package operations\n(can be specified multiple times)")
 	_ = fs.String("config", "", "path to `file` containing configuration values (optional)")
 
-	ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix("YGG"), ff.WithConfigFileFlag("config"), ff.WithConfigFileParser(fftoml.Parser))
+	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix("YGG"), ff.WithConfigFileFlag("config"), ff.WithConfigFileParser(fftoml.Parser)); err != nil {
+		log.Fatal(err)
+	}
 
 	if logLevel.Value != "" {
 		l, err := log.ParseLevel(logLevel.Value)


### PR DESCRIPTION
It also fixes an `errcheck` lint issue when parsing the flags in the
flag set with `ff.Parse`.

Signed-off-by: Gael Chamoulaud (Strider) <gchamoul@redhat.com>