### PR TITLE
ci: encode build date and commit in release

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,6 +9,7 @@ srpm_build_deps:
   - go-rpm-macros
   - meson
   - "pkgconfig(dbus-1)"
+  - "rpm_macro(forgemeta)"
   - rpm-build
 
 actions:

--- a/dist/srpm/yggdrasil-worker-package-manager.spec.in
+++ b/dist/srpm/yggdrasil-worker-package-manager.spec.in
@@ -6,6 +6,7 @@
 %global goipath         github.com/redhatinsights/yggdrasil-worker-package-manager
 Version:                @VERSION@
 %global commit          @COMMIT@
+%global date            %(date "+%Y%m%d")
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global archivename     yggdrasil-worker-package-manager-%{version}
 
@@ -16,8 +17,9 @@ Version:                @VERSION@
 %global gomodulesmode GO111MODULES=off
 %global gosource %{gourl}/releases/download/%{version}/%{name}-%{version}.tar.gz
 %global gocompilerflags "-buildmode pie -compiler gc"
+%global scm git
+%forgemeta
 %endif
-
 
 %if 0%{?fedora}
 %global setup_flags -Dvendor=False
@@ -36,7 +38,7 @@ the provided allow-pattern regular expressions.}
 %global godocs          README.md
 
 Name:           yggdrasil-worker-package-manager
-Release:        0%{?dist}
+Release:        99%{?dist}
 Summary:        Package manager worker for yggdrasil
  
 License:        GPL-3.0-only


### PR DESCRIPTION
Use a hard-coded high value (99) for the release field. Adjust the macros needed by forgemeta so that the SCM information is encoded in the distprefix.