### PR TITLE
chore: Update go to 1.23 in go.mod

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,9 +14,7 @@ srpm_build_deps:
 
 actions:
   post-upstream-clone:
-    - go install golang.org/dl/go1.21.13@latest
-    - bash -c "$(go env GOPATH)/bin/go1.21.13 download"
-    - bash -c "PATH=$HOME/sdk/go1.21.13/bin:$PATH meson setup builddir -Dbuild_srpm=True -Dvendor=True"
+    - meson setup builddir -Dbuild_srpm=True -Dvendor=True --wipe
     - meson compile tarball -C builddir
   get-current-version:
     - awk '/^Version:/ {print $2;}' builddir/dist/srpm/yggdrasil-worker-package-manager.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,7 +34,6 @@ jobs:
       - centos-stream-9
       - centos-stream-10
       - fedora-all
-      - rhel-8
       - rhel-9
       - rhel-10
 
@@ -84,9 +83,6 @@ jobs:
     trigger: pull_request
     identifier: "unit/rhel"
     targets:
-      rhel-8-x86_64:
-        distros:
-          - RHEL-8-Nightly
       rhel-9-x86_64:
         distros:
           - RHEL-9-Nightly

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/redhatinsights/yggdrasil-worker-package-manager
 
-go 1.21
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
* Card ID: CCT-1330
* Update go version to 1.23 to be compatible with majority of go modules used by yggdrasil-worker-package-manager
* Added toolchain to go.mod file