### PR TITLE
chore(ci): Fix meson builds

### DIFF
--- a/build-aux/vendor.sh
+++ b/build-aux/vendor.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Try to go to MESON_DIST_ROOT if this env. variable is defined
+# and the directory exists
+if [[ -n "${MESON_DIST_ROOT}" && -d "${MESON_DIST_ROOT}" ]]; then
 pushd "${MESON_DIST_ROOT}" || exit 1
+fi
+
 go mod vendor
+
+if [[ -n "${MESON_DIST_ROOT}" && -d "${MESON_DIST_ROOT}" ]]; then
 popd || exit 1
+fi


### PR DESCRIPTION
This patch attempts to fix meson build issues on the main branch due to changes in MESON_DIST_ROOT behavior. This change was recently pushed to yggdrasil to resolve identical issues with the meson builds in the CI.

Reference: https://github.com/RedHatInsights/yggdrasil/commit/e98162689211e4268c5f7dafdd40d3c82fba170f
