### PR TITLE
fix: (0.1-backport) prevent argument injection in APT backend

### DIFF
--- a/package_manager_apt.go
+++ b/package_manager_apt.go
@@ -61,7 +61,7 @@ func (p *PackageManagerApt) DisableRepo(sourceLine string) (stdout, stderr []byt
 }
 
 func (p *PackageManagerApt) run(command string, args ...string) (stdout, stderr []byte, code int, err error) {
-	cmdargs := []string{"--assume-yes", command}
+	cmdargs := []string{"--assume-yes", command, "--"}
 	cmdargs = append(cmdargs, args...)
 	cmd := exec.Command("/usr/bin/apt-get", cmdargs...)
 	stdout, stderr, code, err = run(cmd)


### PR DESCRIPTION
This patch inserts a "--" (end-of-options) before user-supplied package names passed to apt-get to prevent option injection via names beginning with "-".

Resolves: CCT-2789