### PR TITLE
fix: (release-0.1) resolve golangci-lint errcheck and staticcheck findings

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sgreben/flagvar"
 	"github.com/zcalusic/sysinfo"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -37,7 +38,9 @@ func main() {
 	fs.Var(&allowPatterns, "allow-pattern", "regular expression pattern to allow package operations\n(can be specified multiple times)")
 	_ = fs.String("config", filepath.Join(yggdrasil.SysconfDir, yggdrasil.LongName, "workers", fileName+".toml"), "path to `file` containing configuration values (optional)")
 
-	ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix("YGG"), ff.WithConfigFileFlag("config"), ff.WithConfigFileParser(fftoml.Parser))
+	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix("YGG"), ff.WithConfigFileFlag("config"), ff.WithConfigFileParser(fftoml.Parser)); err != nil {
+		log.Fatalf("cannot parse flags: %v", err)
+	}
 
 	if logLevel.Value != "" {
 		l, err := log.ParseLevel(logLevel.Value)
@@ -51,12 +54,15 @@ func main() {
 		log.SetFlags(log.LstdFlags | log.Llongfile)
 	}
 
-	// Dial the dispatcher on its well-known address.
-	conn, err := grpc.Dial(socketAddr, grpc.WithInsecure())
+	conn, err := grpc.NewClient(socketAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Warnf("cannot close dispatcher connection: %v", err)
+		}
+	}()
 
 	// Create a dispatcher client
 	c := pb.NewDispatcherClient(conn)

--- a/package_manager_dnf.go
+++ b/package_manager_dnf.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,7 +17,7 @@ func (p *PackageManagerDnf) Uninstall(name string) (stdout, stderr []byte, code 
 }
 
 func (p *PackageManagerDnf) AddRepo(name string, content []byte) (stdout, stderr []byte, code int, err error) {
-	return nil, nil, -1, ioutil.WriteFile(filepath.Join("/etc/yum.repos.d/", canonicalizeRepoName(name, ".repo")), content, 0644)
+	return nil, nil, -1, os.WriteFile(filepath.Join("/etc/yum.repos.d/", canonicalizeRepoName(name, ".repo")), content, 0644)
 }
 
 func (p *PackageManagerDnf) RemoveRepo(name string) (stdout, stderr []byte, code int, err error) {

--- a/package_manager_yum.go
+++ b/package_manager_yum.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,7 +17,7 @@ func (p *PackageManagerYum) Uninstall(name string) (stdout, stderr []byte, code 
 }
 
 func (p *PackageManagerYum) AddRepo(name string, content []byte) (stdout, stderr []byte, code int, err error) {
-	return nil, nil, -1, ioutil.WriteFile(filepath.Join("/etc/yum.repos.d/", canonicalizeRepoName(name, ".repo")), content, 0644)
+	return nil, nil, -1, os.WriteFile(filepath.Join("/etc/yum.repos.d/", canonicalizeRepoName(name, ".repo")), content, 0644)
 }
 
 func (p *PackageManagerYum) RemoveRepo(name string) (stdout, stderr []byte, code int, err error) {

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/redhatinsights/yggdrasil/protocol"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type Message struct {
@@ -154,11 +155,15 @@ func (s *Server) Send(ctx context.Context, d *protocol.Data) (*protocol.Receipt,
 }
 
 func (s *Server) returnData(d *protocol.Data) error {
-	conn, err := grpc.Dial(s.dispatchAddr, grpc.WithInsecure())
+	conn, err := grpc.NewClient(s.dispatchAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("cannot dial dispatcher: %w", err)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Warnf("cannot close dispatcher connection: %v", err)
+		}
+	}()
 
 	c := protocol.NewDispatcherClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/util.go
+++ b/util.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
+
+	"git.sr.ht/~spc/go-log"
 )
 
 // canonicalizeRepoName converts the string filename into a suitable filename.
@@ -20,7 +21,11 @@ func readLines(name string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot open file for reading: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Warnf("cannot close file %v: %v", name, err)
+		}
+	}()
 
 	var lines []string
 	scanner := bufio.NewScanner(file)
@@ -45,13 +50,17 @@ func writeLines(name string, lines []string, truncate bool) error {
 	}
 
 	if truncate {
-		return ioutil.WriteFile(name, data, 0644)
+		return os.WriteFile(name, data, 0644)
 	} else {
 		file, err := os.OpenFile(name, os.O_WRONLY|os.O_APPEND, 0644)
 		if err != nil {
 			return fmt.Errorf("cannot open file for appending: %w", err)
 		}
-		defer file.Close()
+		defer func() {
+			if err := file.Close(); err != nil {
+				log.Warnf("cannot close file %v: %v", name, err)
+			}
+		}()
 
 		if _, err := file.Write(data); err != nil {
 			return fmt.Errorf("cannot write to file: %w", err)


### PR DESCRIPTION
Replace deprecated grpc.Dial/WithInsecure with grpc.NewClient and transport credentials, swap io/ioutil for os package equivalents, and check all previously-ignored error returns from Close and Parse.

Resolves: CCT-2815